### PR TITLE
Bug/pandroid 6

### DIFF
--- a/sdk/src/main/java/com/podio/sdk/domain/field/DateField.java
+++ b/sdk/src/main/java/com/podio/sdk/domain/field/DateField.java
@@ -20,10 +20,12 @@ public class DateField extends Field<DateField.Value> {
         private Boolean calendar = null;
         private final String end = null;
         private String time = null;
+        private Boolean isCreateViewEditHidden = null;
 
-        public Settings(Boolean calendar, String time){
+        public Settings(Boolean calendar, String time, Boolean isCreateViewEditHidden){
             this.calendar = calendar;
             this.time = time;
+            this.isCreateViewEditHidden = isCreateViewEditHidden;
         }
     }
 
@@ -66,6 +68,14 @@ public class DateField extends Field<DateField.Value> {
             } catch (IllegalArgumentException e) {
                 return State.undefined;
             }
+        }
+
+        @Override
+        public boolean getIsHiddenCreateViewEdit() {
+            if(settings != null && settings.isCreateViewEditHidden != null) {
+                return settings.isCreateViewEditHidden;
+            }
+            return super.getIsHiddenCreateViewEdit();
         }
     }
 
@@ -293,7 +303,8 @@ public class DateField extends Field<DateField.Value> {
     public DateField(CalculationField calculationField){
         super(calculationField);
 
-        this.config = new Configuration(new Settings(calculationField.getConfiguration().isCalendar(),calculationField.getConfiguration().getTimeState()));
+        final CalculationField.Configuration configuration = calculationField.getConfiguration();
+        this.config = new Configuration(new Settings(configuration.isCalendar(), configuration.getTimeState(), configuration.getIsHiddenCreateViewEdit()));
         this.values = new ArrayList<>();
         for (Field.Value calcValue : calculationField.getValues()) {
             this.values.add((DateField.Value)calcValue);

--- a/sdk/src/main/java/com/podio/sdk/domain/field/NumberField.java
+++ b/sdk/src/main/java/com/podio/sdk/domain/field/NumberField.java
@@ -17,9 +17,11 @@ public class NumberField extends Field<NumberField.Value> {
      */
     private static class Settings {
         private Integer decimals = null;
+        private Boolean isCreateViewEditHidden = null;
 
-        public Settings(Integer decimals) {
+        public Settings(Integer decimals, boolean isCreateViewEdithidden) {
             this.decimals = decimals;
+            this.isCreateViewEditHidden = isCreateViewEdithidden;
         }
     }
 
@@ -41,6 +43,14 @@ public class NumberField extends Field<NumberField.Value> {
 
         public int getNumberOfDecimals() {
             return settings != null ? Utils.getNative(settings.decimals, 0) : 0;
+        }
+
+        @Override
+        public boolean getIsHiddenCreateViewEdit() {
+            if(settings != null && settings.isCreateViewEditHidden != null) {
+                return settings.isCreateViewEditHidden;
+            }
+            return super.getIsHiddenCreateViewEdit();
         }
     }
 
@@ -107,7 +117,8 @@ public class NumberField extends Field<NumberField.Value> {
     public NumberField(CalculationField calculationField) {
         super(calculationField);
 
-        config = new Configuration(new Settings(calculationField.getConfiguration().getNumberOfDecimals()));
+        final CalculationField.Configuration configuration = calculationField.getConfiguration();
+        config = new Configuration(new Settings(configuration.getNumberOfDecimals(), configuration.getIsHiddenCreateViewEdit()));
 
         this.values = new ArrayList<>();
         for (Field.Value calcValue : calculationField.getValues()) {

--- a/sdk/src/main/java/com/podio/sdk/domain/field/TextField.java
+++ b/sdk/src/main/java/com/podio/sdk/domain/field/TextField.java
@@ -19,6 +19,11 @@ public class TextField extends Field<TextField.Value> {
      */
     private static class Settings {
         private final String size = null;
+        private Boolean isCreateViewEditHidden = null;
+
+        public Settings(boolean isCreateViewEdithidden) {
+            this.isCreateViewEditHidden = isCreateViewEdithidden;
+        }
     }
 
     /**
@@ -29,8 +34,8 @@ public class TextField extends Field<TextField.Value> {
         private final Value default_value = null;
         private Settings settings = null;
 
-        public Configuration() {
-            settings = new Settings();
+        public Configuration(Settings settings) {
+            this.settings = settings;
         }
 
         public Value getDefaultValue() {
@@ -45,6 +50,14 @@ public class TextField extends Field<TextField.Value> {
             } catch (IllegalArgumentException e) {
                 return Size.undefined;
             }
+        }
+
+        @Override
+        public boolean getIsHiddenCreateViewEdit() {
+            if(settings != null && settings.isCreateViewEditHidden != null) {
+                return settings.isCreateViewEditHidden;
+            }
+            return super.getIsHiddenCreateViewEdit();
         }
     }
 
@@ -115,7 +128,7 @@ public class TextField extends Field<TextField.Value> {
     public TextField(CalculationField calculationField) {
         super(calculationField);
 
-        config = new Configuration();
+        config = new Configuration(new Settings(calculationField.getConfiguration().getIsHiddenCreateViewEdit()));
         this.values = new ArrayList<>();
         for (Field.Value calcValue : calculationField.getValues()) {
             this.values.add((TextField.Value)calcValue);


### PR DESCRIPTION
To respect the create_edit_view_hidden flag on calculation fields, we need to some extra processing. A calculation field is translated into either a date, number or text field. 
Hence the configurations of the calculation fields needs to be transferred over to these fields. 
We use a settings object to transfer these config values over to the other fields. 